### PR TITLE
fix: pnpm 11 esbuild build script approval

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
           run_install: false
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 node_modules
 coverage/
+.mcp.json
+.claude/

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
## Problem

Running any `pnpm` script (e.g. `pnpm run test`) failed with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.21.5

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

pnpm v11 introduced a security feature that blocks packages from running native install scripts unless explicitly approved. `esbuild` requires a postinstall script to download its platform-specific binary — without approval, `pnpm install` exits with code 1 before any scripts can run.

Running `pnpm approve-builds` (the suggested fix) made things worse: it generated a broken `pnpm-workspace.yaml` missing the required `packages` field, causing every subsequent pnpm command to fail with `packages field missing or empty`. This is a [known pnpm bug (#9361)](https://github.com/pnpm/pnpm/issues/9361).

## Root Cause

Two compounding issues:

1. **Version mismatch** — the VS Code task runner was using pnpm **11.3.0** (global install) while the terminal had pnpm **9.6.0** via Volta. Running `pnpm approve-builds` from the terminal used the older version, which generated an incompatible workspace file format.
2. **Missing build approval** — pnpm 11 requires `allowBuilds` in `pnpm-workspace.yaml` to permit esbuild's postinstall script. Without it, installation always fails.

## Fix

Add `pnpm-workspace.yaml` with esbuild explicitly approved using pnpm 11's `allowBuilds` format:

```yaml
allowBuilds:
  esbuild: true
```

## Notes

- `onlyBuiltDependencies` (pnpm 9/10 format) and the `pnpm` key in `package.json` are both **ignored** in pnpm 11 — `allowBuilds` in `pnpm-workspace.yaml` is the correct location
- Do **not** run `pnpm approve-builds` on pnpm < 11 — it regenerates the workspace file with an incompatible format that breaks all subsequent pnpm commands