### PR TITLE
feat: grow adoption through discoverability and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ or with pnpm:
 pnpm install accent-folding
 ```
 
+or with bun:
+
+```shell
+bun add accent-folding
+```
+
 or with yarn:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ input.addEventListener('input', () => {
     : names;
 
   list.innerHTML = matches
-    .map(name => `<li>${af.highlightMatch(name, query)}</li>`)
+    .map(name => `<li>${query ? af.highlightMatch(name, query) : name}</li>`)
     .join('');
 });
 ```
@@ -141,7 +141,7 @@ export default function AccentSearch() {
       <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Search..." />
       <ul>
         {matches.map(name => (
-          <li key={name} dangerouslySetInnerHTML={{ __html: af.highlightMatch(name, query) }} />
+          <li key={name} dangerouslySetInnerHTML={{ __html: query ? af.highlightMatch(name, query) : name }} />
         ))}
       </ul>
     </div>
@@ -149,7 +149,7 @@ export default function AccentSearch() {
 }
 ```
 
-`dangerouslySetInnerHTML` is safe here because the strings come from your own data, not user-generated HTML.
+`dangerouslySetInnerHTML` is safe here because `names` is app-controlled data. Never use it with strings from untrusted external input.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # accent-folding [![npm version](https://img.shields.io/npm/v/accent-folding)](https://www.npmjs.com/package/accent-folding) [![npm downloads](https://img.shields.io/npm/dw/accent-folding)](https://www.npmjs.com/package/accent-folding) ![GitHub package.json version](https://img.shields.io/github/package-json/v/ZRktty/accent-folding) [![Coverage Status](https://coveralls.io/repos/github/ZRktty/accent-folding/badge.svg?branch=main)](https://coveralls.io/github/ZRktty/accent-folding?branch=main)
 
+**[Live demo →](https://zrktty.github.io/accent-folding/)**
+
 Searching "cafe" should find "café". Highlighting "lo" in "López" should show `<b>Ló</b>pez` — not stripped text.
 
 `accent-folding` is the only library that solves both: accent-insensitive matching that returns the **original accented string** with HTML markup around matches. Zero dependencies. 2.7 kB gzipped.
@@ -158,7 +160,7 @@ Node.js ≥22
 
 Install with npm:
 
-```
+```shell
 npm install accent-folding@1
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# accent-folding ![GitHub package.json version](https://img.shields.io/github/package-json/v/zr87/accent-folding) [![Coverage Status](https://coveralls.io/repos/github/zr87/accent-folding/badge.svg?branch=main)](https://coveralls.io/github/zr87/accent-folding?branch=main)
+# accent-folding [![npm version](https://img.shields.io/npm/v/accent-folding)](https://www.npmjs.com/package/accent-folding) [![npm downloads](https://img.shields.io/npm/dw/accent-folding)](https://www.npmjs.com/package/accent-folding) ![GitHub package.json version](https://img.shields.io/github/package-json/v/ZRktty/accent-folding) [![Coverage Status](https://coveralls.io/repos/github/ZRktty/accent-folding/badge.svg?branch=main)](https://coveralls.io/github/ZRktty/accent-folding?branch=main)
 
-## Description
+Searching "cafe" should find "café". Highlighting "lo" in "López" should show `<b>Ló</b>pez` — not stripped text.
 
-A case-insensitive accent folding functions to replace accented characters with their unaccented equivalents
-or hightlight matched terms in a string, ignoring accents.
+`accent-folding` is the only library that solves both: accent-insensitive matching that returns the **original accented string** with HTML markup around matches. Zero dependencies. 2.7 kB gzipped.
 
 ## Installation
 
@@ -19,7 +18,7 @@ or with pnpm:
 pnpm install accent-folding
 ```
 
-or even with yarn:
+or with yarn:
 
 ```shell
 yarn add accent-folding
@@ -27,11 +26,33 @@ yarn add accent-folding
 
 ## Public Methods
 
+### `highlightMatch`
+
+Matches a search fragment against a string, ignoring accents, and wraps each match in an HTML tag — returning the original accented characters intact.
+
+- Accent-insensitive matching
+- Returns original accented text with HTML markup around matches
+- Customizable highlight tag (default: `<b>`, use `strong`, `mark`, `span`, etc.)
+- Handles various Unicode characters, including fullwidth ASCII
+
+```js
+import AccentFolding from 'accent-folding';
+
+const af = new AccentFolding();
+
+af.highlightMatch('Fulanilo López', 'lo'); // --> "Fulani<b>lo</b> <b>Ló</b>pez"
+```
+
+Use the third argument to specify the wrapping HTML tag:
+
+```js
+af.highlightMatch('Fulanilo López', 'lo', 'strong'); // --> "Fulani<strong>lo</strong> <strong>Ló</strong>pez"
+af.highlightMatch('Fulanilo López', 'lo', 'mark');   // --> "Fulani<mark>lo</mark> <mark>Ló</mark>pez"
+```
+
 ### `replace`
 
 Replaces accented characters in a string with their unaccented equivalents.
-
-#### Key Features:
 
 - Handles various Unicode characters, including fullwidth ASCII
 - Preserves original string formatting in the output
@@ -42,37 +63,6 @@ import AccentFolding from 'accent-folding';
 const af = new AccentFolding();
 
 af.replace('Fulanilo López'); // --> "Fulanilo Lopez"
-```
-
-### `highlightMatch`
-
-Highlights matched terms in a string, ignoring accents.
-
-#### Key Features:
-
-- Accent-insensitive matching
-- Customizable highlight wrapping (can use any HTML tag)
-- Preserves original string formatting in the output
-- Handles various Unicode characters, including fullwidth ASCII
-- wraps string fragment in `<b>` html tag by default.
-
-#### Potential Use Cases:
-
-- Search functionality in applications where accents should be ignored
-- Highlighting matched terms in search results
-
-```js
-import AccentFolding from 'accent-folding';
-
-const af = new AccentFolding();
-
-af.highlightMatch('Fulanilo López', 'lo'); // --> "Fulani<b>lo</b> <b>Ló</b>pez"
-```
-
-Use the 3d argument to specify the wrapping html tag (strong, em, span etc.):
-
-```js
-af.highlightMatch('Fulanilo López', 'lo', 'strong'); // --> "Fulani<strong>lo</strong> <strong>Ló</strong>pez"
 ```
 
 ## Extending and Overriding the Accent Map
@@ -95,9 +85,10 @@ console.log(accentFolder.replace('✝illa')); // Outputs: tilla
 
 ## Requirements
 
-Node.js version 14.7 or higher
+Node.js ≥22
 
-## Legacy usage (v1)
+<details>
+<summary>Legacy usage (v1 CommonJS API)</summary>
 
 Install with npm:
 
@@ -114,9 +105,7 @@ accentFoldedHighlight('Fulanilo López', 'lo'); // --> "Fulani<b>lo</b> <b>Ló</
 accentFoldedHighlight('Fulanilo López', 'lo', 'strong'); // --> "Fulani<strong>lo</strong> <strong>Ló</strong>pez"
 ```
 
-## Roadmap
-
-See the [Roadmap](./ROADMAP.md 'View the project roadmap') for planned features and future improvements.
+</details>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,66 @@ console.log(accentFolder.replace('Föhn')); // Outputs: Foehn
 console.log(accentFolder.replace('✝illa')); // Outputs: tilla
 ```
 
+## Real-World Examples
+
+### Plain JS (browser)
+
+```js
+import AccentFolding from 'accent-folding';
+
+const af = new AccentFolding();
+const names = ['López', 'Müller', 'Björk', 'Ñoño', 'García', 'Renée'];
+
+const input = document.querySelector('#search');
+const list  = document.querySelector('#results');
+
+input.addEventListener('input', () => {
+  const query = input.value.trim();
+  const matches = query
+    ? names.filter(name =>
+        af.replace(name).toLowerCase().includes(af.replace(query).toLowerCase())
+      )
+    : names;
+
+  list.innerHTML = matches
+    .map(name => `<li>${af.highlightMatch(name, query)}</li>`)
+    .join('');
+});
+```
+
+### React
+
+```jsx
+import { useState } from 'react';
+import AccentFolding from 'accent-folding';
+
+const af = new AccentFolding();
+const names = ['López', 'Müller', 'Björk', 'Ñoño', 'García', 'Renée'];
+
+export default function AccentSearch() {
+  const [query, setQuery] = useState('');
+
+  const matches = query
+    ? names.filter(name =>
+        af.replace(name).toLowerCase().includes(af.replace(query).toLowerCase())
+      )
+    : names;
+
+  return (
+    <div>
+      <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Search..." />
+      <ul>
+        {matches.map(name => (
+          <li key={name} dangerouslySetInnerHTML={{ __html: af.highlightMatch(name, query) }} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+`dangerouslySetInnerHTML` is safe here because the strings come from your own data, not user-generated HTML.
+
 ## Requirements
 
 Node.js ≥22

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,7 +84,7 @@
   <h2>Vanilla JS <span class="badge badge-js">browser</span></h2>
   <input type="text" id="js-query" placeholder="Search names..." autocomplete="off" />
   <div class="controls">
-    <span>Wrap tag:</span>
+    <label for="js-tag">Wrap tag:</label>
     <select id="js-tag">
       <option value="b">b (default)</option>
       <option value="strong">strong</option>
@@ -110,7 +110,7 @@
 </div>
 
 <script type="module">
-  import AccentFolding from 'https://esm.sh/accent-folding';
+  import AccentFolding from 'https://esm.sh/accent-folding@2.2.0';
 
   const names = ['López', 'Müller', 'Björk', 'Ñoño', 'García', 'Renée', 'Ångström', 'Čehov', 'Dubček'];
   const af    = new AccentFolding();
@@ -150,7 +150,7 @@
   import { createElement, useState } from 'https://esm.sh/react@18';
   import { createRoot }              from 'https://esm.sh/react-dom@18/client';
   import htm                         from 'https://esm.sh/htm';
-  import AccentFolding               from 'https://esm.sh/accent-folding';
+  import AccentFolding               from 'https://esm.sh/accent-folding@2.2.0';
 
   const html  = htm.bind(createElement);
   const af    = new AccentFolding();
@@ -174,8 +174,8 @@
           autoComplete="off"
         />
         <div className="controls">
-          <span>Wrap tag:</span>
-          <select value=${tag} onChange=${e => setTag(e.target.value)}>
+          <label htmlFor="react-tag">Wrap tag:</label>
+          <select id="react-tag" value=${tag} onChange=${e => setTag(e.target.value)}>
             <option value="b">b (default)</option>
             <option value="strong">strong</option>
             <option value="mark">mark</option>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>accent-folding demo</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 2rem 1rem;
+      color: #1a1a1a;
+    }
+    h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+    h1 a { color: inherit; text-decoration: none; opacity: 0.45; font-size: 0.9rem; }
+    h1 a:hover { opacity: 1; }
+    .subtitle { color: #6b7280; margin-bottom: 2.5rem; }
+    h2 { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; }
+    .badge {
+      display: inline-block;
+      font-size: 0.7rem;
+      font-weight: 500;
+      padding: 0.15rem 0.5rem;
+      border-radius: 100px;
+      vertical-align: middle;
+      margin-left: 0.4rem;
+    }
+    .badge-js    { background: #fef3c7; color: #92400e; }
+    .badge-react { background: #dbeafe; color: #1d4ed8; }
+    .demo {
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 1.5rem;
+      margin-bottom: 2rem;
+    }
+    input[type="text"] {
+      width: 100%;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      font-size: 1rem;
+      margin-bottom: 0.75rem;
+      outline: none;
+    }
+    input[type="text"]:focus { border-color: #6b7280; }
+    .controls {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+      font-size: 0.85rem;
+      color: #6b7280;
+    }
+    .controls select {
+      padding: 0.2rem 0.4rem;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      font-size: 0.85rem;
+    }
+    table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    th {
+      text-align: left;
+      padding: 0.4rem 0.6rem;
+      color: #6b7280;
+      font-weight: 500;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    td { padding: 0.45rem 0.6rem; border-bottom: 1px solid #f3f4f6; }
+    td:nth-child(2), td:nth-child(3) { font-family: ui-monospace, monospace; font-size: 0.825rem; }
+    td b, td strong { background: #fef9c3; font-weight: inherit; }
+    td mark { background: #fef9c3; padding: 0; }
+    td span { background: #fef9c3; }
+    .empty { color: #9ca3af; font-style: italic; }
+  </style>
+</head>
+<body>
+
+<h1>accent-folding <a href="https://github.com/ZRktty/accent-folding" target="_blank" rel="noopener">↗</a></h1>
+<p class="subtitle">Accent-insensitive matching with built-in search highlighting — try typing <strong>lo</strong>, <strong>mu</strong>, <strong>gar</strong>, or <strong>bj</strong></p>
+
+<div class="demo">
+  <h2>Vanilla JS <span class="badge badge-js">browser</span></h2>
+  <input type="text" id="js-query" placeholder="Search names..." autocomplete="off" />
+  <div class="controls">
+    <span>Wrap tag:</span>
+    <select id="js-tag">
+      <option value="b">b (default)</option>
+      <option value="strong">strong</option>
+      <option value="mark">mark</option>
+      <option value="span">span</option>
+    </select>
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Original name</th>
+        <th>replace(name)</th>
+        <th>highlightMatch(name, query)</th>
+      </tr>
+    </thead>
+    <tbody id="js-results"></tbody>
+  </table>
+</div>
+
+<div class="demo">
+  <h2>React <span class="badge badge-react">component</span></h2>
+  <div id="react-root"></div>
+</div>
+
+<script type="module">
+  import AccentFolding from 'https://esm.sh/accent-folding';
+
+  const names = ['López', 'Müller', 'Björk', 'Ñoño', 'García', 'Renée', 'Ångström', 'Čehov', 'Dubček'];
+  const af    = new AccentFolding();
+
+  const queryEl = document.getElementById('js-query');
+  const tagEl   = document.getElementById('js-tag');
+  const tbody   = document.getElementById('js-results');
+
+  function render() {
+    const q   = queryEl.value.trim();
+    const tag = tagEl.value;
+
+    const rows = q
+      ? names.filter(n => af.replace(n).toLowerCase().includes(af.replace(q).toLowerCase()))
+      : names;
+
+    if (!rows.length) {
+      tbody.innerHTML = '<tr><td colspan="3" class="empty">No matches</td></tr>';
+      return;
+    }
+
+    tbody.innerHTML = rows.map(n => `
+      <tr>
+        <td>${n}</td>
+        <td>${af.replace(n)}</td>
+        <td>${q ? af.highlightMatch(n, q, tag) : n}</td>
+      </tr>
+    `).join('');
+  }
+
+  queryEl.addEventListener('input', render);
+  tagEl.addEventListener('change', render);
+  render();
+</script>
+
+<script type="module">
+  import { createElement, useState } from 'https://esm.sh/react@18';
+  import { createRoot }              from 'https://esm.sh/react-dom@18/client';
+  import htm                         from 'https://esm.sh/htm';
+  import AccentFolding               from 'https://esm.sh/accent-folding';
+
+  const html  = htm.bind(createElement);
+  const af    = new AccentFolding();
+  const names = ['López', 'Müller', 'Björk', 'Ñoño', 'García', 'Renée', 'Ångström', 'Čehov', 'Dubček'];
+
+  function AccentSearch() {
+    const [query, setQuery] = useState('');
+    const [tag,   setTag]   = useState('b');
+
+    const rows = query
+      ? names.filter(n => af.replace(n).toLowerCase().includes(af.replace(query).toLowerCase()))
+      : names;
+
+    return html`
+      <div>
+        <input
+          type="text"
+          value=${query}
+          onInput=${e => setQuery(e.target.value)}
+          placeholder="Search names..."
+          autoComplete="off"
+        />
+        <div className="controls">
+          <span>Wrap tag:</span>
+          <select value=${tag} onChange=${e => setTag(e.target.value)}>
+            <option value="b">b (default)</option>
+            <option value="strong">strong</option>
+            <option value="mark">mark</option>
+            <option value="span">span</option>
+          </select>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Original name</th>
+              <th>replace(name)</th>
+              <th>highlightMatch(name, query)</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows.length === 0
+              ? html`<tr><td colSpan="3" className="empty">No matches</td></tr>`
+              : rows.map(n => html`
+                  <tr key=${n}>
+                    <td>${n}</td>
+                    <td>${af.replace(n)}</td>
+                    <td dangerouslySetInnerHTML=${{ __html: query ? af.highlightMatch(n, query, tag) : n }} />
+                  </tr>
+                `)
+            }
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  createRoot(document.getElementById('react-root')).render(html`<${AccentSearch} />`);
+</script>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accent-folding",
   "version": "2.2.0",
-  "description": "A JavaScript library for accent-insensitive text processing, including accent folding and search term highlighting",
+  "description": "Accent-insensitive text matching with built-in search highlighting — the only library that returns original accented text with HTML markup around matches",
   "main": "index.js",
   "engines": {
     "node": ">=22"
@@ -17,26 +17,33 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zr87/accent-folding.git"
+    "url": "git+https://github.com/ZRktty/accent-folding.git"
   },
   "keywords": [
     "accent folding",
     "accent insensitive",
-    "Unicode normalization",
-    "text processing",
-    "string manipulation",
+    "accent insensitive search",
+    "accent search",
+    "accent removal",
+    "diacritics",
+    "diacritic highlight",
+    "highlight match",
     "search highlight",
-    "JavaScript library",
-    "npm package",
+    "search input",
+    "autocomplete",
+    "typeahead",
+    "fuzzy search display",
+    "Unicode normalization",
     "text normalization",
-    "accent removal"
+    "text processing",
+    "string manipulation"
   ],
-  "author": "Zoltan Rakottyai <zoltanrakottyai@pm.me>",
+  "author": "Zoltan Rakottyai <zoltan@zrktty.dev>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/zr87/accent-folding/issues"
+    "url": "https://github.com/ZRktty/accent-folding/issues"
   },
-  "homepage": "https://github.com/zr87/accent-folding#readme",
+  "homepage": "https://github.com/ZRktty/accent-folding#readme",
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@vitest/coverage-v8": "^2.0.5",


### PR DESCRIPTION
## Summary

- **U1 — npm metadata**: fix stale `zr87` → `ZRktty` URLs; sharpen description to lead with `highlightMatch`; expand keywords with UI-engineer search terms (`diacritic highlight`, `highlight match`, `autocomplete`, `typeahead`, etc.); drop noise keywords
- **U2 — README restructure**: lead with `highlightMatch` (the unique differentiator) before `replace`; punchy problem-framing opener; add npm version + downloads badges; fix `hightlight` typo; update requirements to Node.js ≥22; collapse legacy v1 CJS section; remove internal Roadmap link; add Bun install example
- **U3 — Integration examples**: plain JS (browser) and React component showing the full loop — accent-insensitive filter + highlighted results — with accented name dataset (López, Müller, Björk…)
- **GitHub Pages demo**: `docs/index.html` — zero build step, imports from esm.sh; two side-by-side interactive demos (vanilla JS + React) showing both `replace()` and `highlightMatch()` with a wrap-tag selector

No API changes. All 728 tests continue to pass.

## Enabling the live demo

Settings → Pages → Source: Deploy from branch → Branch: `main`, Folder: `/docs`

Demo URL: https://zrktty.github.io/accent-folding/

## Test plan

- [ ] `pnpm test` passes
- [ ] `npm pack --dry-run` shows updated description and keywords
- [ ] README renders correctly on GitHub — `highlightMatch` section appears before `replace`, badges load, legacy section is collapsed
- [ ] Live demo loads and both vanilla JS and React demos respond to search input