### PR TITLE
fix: replace bare JSON import with createRequire for Node.js ESM compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ cd demo && pnpm dev
 
 ## Requirements
 
-Node.js ≥22
+Node.js ≥18
 
 <details>
 <summary>Legacy usage (v1 CommonJS API)</summary>

--- a/docs/plans/2026-05-25-003-feat-dx-tooling-plan.md
+++ b/docs/plans/2026-05-25-003-feat-dx-tooling-plan.md
@@ -7,6 +7,7 @@ created: 2026-05-25
 ## Problem
 
 Developer experience friction identified during TypeScript declaration work:
+
 - Prettier drift accumulates across commits and gets cleaned up reactively rather than at commit time
 - No validation that the published package shape is correct for npm consumers
 - TypeScript declarations ship but are not verified from a real consumer's perspective
@@ -25,10 +26,12 @@ Add four lightweight tools. No build step changes, no source migration.
 **Goal:** Run prettier + eslint on staged files before every commit. Eliminates prettier drift.
 
 **Files:**
+
 - Create: `.husky/pre-commit`
 - Modify: `package.json` — add `lint-staged` config and `prepare` script
 
 **Approach:**
+
 - `pnpm add -D husky lint-staged`
 - `pnpm exec husky init` — creates `.husky/pre-commit`
 - Hook runs `pnpm exec lint-staged`
@@ -50,10 +53,12 @@ Add four lightweight tools. No build step changes, no source migration.
 **Goal:** Validate `package.json` exports, `main`, `types`, and `files` are correct for npm consumers. Run in CI.
 
 **Files:**
+
 - Modify: `package.json` — add `"publint": "publint"` script
 - Modify: `.github/workflows/coverage.yml` — add publint step
 
 **Approach:**
+
 - `publint` is zero-install via `pnpm dlx`, or add as devDependency for CI caching
 - Add script: `"publint": "publint"`
 - CI step after type-check: `pnpm run publint`
@@ -67,10 +72,12 @@ Add four lightweight tools. No build step changes, no source migration.
 **Goal:** Verify TypeScript declarations work correctly from a consumer's perspective across moduleResolution modes (node16, bundler, etc.).
 
 **Files:**
+
 - Modify: `package.json` — add `"attw": "attw --pack ."` script
 - Modify: `.github/workflows/coverage.yml` — add attw step
 
 **Approach:**
+
 - `pnpm add -D @arethetypeswrong/cli`
 - Script: `"attw": "attw --pack ."`
 - CI step after type-check: `pnpm run attw`
@@ -85,10 +92,12 @@ Add four lightweight tools. No build step changes, no source migration.
 **Goal:** Enforce the "2.7 kB gzipped" claim from the README. Fail CI if the package grows beyond a defined threshold.
 
 **Files:**
+
 - Modify: `package.json` — add `size-limit` config and `size` script
 - Modify: `.github/workflows/coverage.yml` — add size-limit step
 
 **Approach:**
+
 - `pnpm add -D size-limit @size-limit/preset-small-lib`
 - Config in `package.json`:
   ```json

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "src/"
   ],
   "engines": {
-    "node": ">=22.22.1"
+    "node": ">=18"
   },
   "type": "module",
   "scripts": {
@@ -43,7 +43,10 @@
     {
       "path": "index.js",
       "limit": "4 kB",
-      "brotli": true
+      "brotli": true,
+      "ignore": [
+        "module"
+      ]
     }
   ],
   "repository": {

--- a/src/accentFolding.js
+++ b/src/accentFolding.js
@@ -1,4 +1,6 @@
-import defaultAccentMap from './accentMap.json';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const defaultAccentMap = require('./accentMap.json');
 
 class AccentFolding {
 	#cache;


### PR DESCRIPTION
## Summary

Fixes #62

The package crashed on import in bare Node.js with `ERR_IMPORT_ATTRIBUTE_MISSING`. Bundler users (Vite, webpack, esbuild) never saw it because bundlers handle JSON imports internally, masking the bug entirely.

## Changes

**`src/accentFolding.js`** — swap bare JSON import for `createRequire`:
```diff
-import defaultAccentMap from './accentMap.json';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const defaultAccentMap = require('./accentMap.json');
```

**`package.json`** — two changes:
- Drop `engines.node` from `>=22.22.1` → `>=18` (the high floor came from `lint-staged`, a devDep; runtime code needs nothing beyond Node 14)
- Add `"ignore": ["module"]` to the `size-limit` entry so esbuild treats the Node.js built-in as external during size checks

## Verified

```
node --input-type=module --eval "
import AccentFolding from './index.js';
const af = new AccentFolding();
console.log(af.replace('café'));            // cafe
console.log(af.highlightMatch('López','lo')); // <b>Ló</b>pez
"
```

- Runtime: ✅ works on bare Node.js (no bundler)
- Tests: ✅ 316/316 passing
- Size: ✅ 706 B brotli (limit 4 kB)

## What was NOT used
- `with { type: 'json' }` — requires Node 22+
- `assert { type: 'json' }` — deprecated/removed
- Inline JSON map — 694 entries, unmaintainable