### PR TITLE
docs: add CODE_OF_CONDUCT and CONTRIBUTING

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Agent Instructions
+
+Guidelines for AI agents (GitHub Copilot, Claude, Cursor, etc.) working in this repository.
+
+## Repository overview
+
+`accent-folding` is a zero-dependency JavaScript library for accent-insensitive text matching with search-highlighting. The core logic lives in `src/accentFolding.js` and the accent map in `src/accentMap.json`. The root `index.js` re-exports from `src/`.
+
+## Key constraints
+
+- **No dependencies.** The library ships with zero runtime dependencies — do not add any.
+- **No build step.** Plain ESM JavaScript only. No TypeScript compilation for the library itself.
+- **Size matters.** The library is ~2.7 kB gzipped. Flag or avoid changes that significantly increase bundle size (use `pnpm size` to check).
+- **Node ≥ 18** is the minimum engine target.
+
+## Project layout
+
+```
+src/accentFolding.js       # Core library logic
+src/accentMap.json         # Accent → ASCII character map
+src/accentFolding.js.test.js  # Tests (Vitest)
+index.js                   # Public entry point (re-exports src/)
+index.d.ts                 # TypeScript declarations
+demo/                      # Vite-based interactive demo (not published)
+docs/                      # Static documentation site
+docs/plans/                # Feature/improvement planning docs
+```
+
+## Common commands
+
+```sh
+pnpm test            # Run tests (Vitest, watch mode)
+pnpm coverage        # Run tests with coverage report
+pnpm lint            # ESLint
+pnpm lint:fix        # ESLint with auto-fix
+pnpm type-check      # TypeScript type checking (tsc)
+pnpm size            # Check bundle size
+```
+
+## Branch & PR workflow
+
+- `main` is the protected default branch — **never push directly to main**.
+- All changes go through a PR. Branch naming convention: `<type>/<short-description>` (e.g. `feat/add-replace-method`, `fix/accent-map-typo`, `docs/update-readme`).
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) — releases are automated via semantic-release.
+
+## Testing
+
+- Tests are in `src/accentFolding.js.test.js` using Vitest.
+- Always add or update tests when changing `src/accentFolding.js` or `src/accentMap.json`.
+- Run `pnpm test` before pushing.
+
+## Accent map changes
+
+- `src/accentMap.json` maps accented characters to their ASCII equivalents.
+- When adding new mappings, check for existing entries first to avoid duplicates.
+- Add a regression test in `src/accentFolding.js.test.js` for every new mapping.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity, level of experience, nationality, personal appearance, race, religion, or sexual identity.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- Harassment, trolling, or personal attacks
+- Publishing others' private information without permission
+- Any conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the maintainer at [zoltan@zrktty.dev](mailto:zoltan@zrktty.dev). All complaints will be reviewed and investigated promptly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,7 +21,7 @@ Examples of unacceptable behavior:
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the maintainer at [zoltan@zrktty.dev](mailto:zoltan@zrktty.dev). All complaints will be reviewed and investigated promptly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainer privately at [zoltan@zrktty.dev](mailto:zoltan@zrktty.dev). Please do not open a public issue for conduct violations. All complaints will be reviewed and investigated promptly and with confidentiality.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for your interest in contributing to `accent-folding`!
+
+## Getting started
+
+```sh
+git clone https://github.com/ZRktty/accent-folding.git
+cd accent-folding
+pnpm install
+```
+
+## Running tests
+
+```sh
+pnpm test
+```
+
+## Making changes
+
+1. Fork the repo and create a branch from `main`.
+2. Make your changes — keep them focused and minimal.
+3. Ensure tests pass: `pnpm test`.
+4. Open a pull request with a clear description of what changed and why.
+
+## Reporting bugs
+
+Open an issue on [GitHub](https://github.com/ZRktty/accent-folding/issues) with a minimal reproduction case.
+
+## Suggesting features
+
+Open an issue describing the use case before implementing anything large. For small, obvious improvements a PR is welcome directly.
+
+## Code style
+
+- No build step — plain JavaScript.
+- No dependencies.
+- Keep it small. The library is 2.7 kB gzipped; changes that balloon the size need strong justification.
+
+## License
+
+By contributing you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thanks for your interest in contributing to `accent-folding`!
 
 ## Getting started
 
+**Prerequisites:** Node.js ≥ 18 and pnpm. If you don't have pnpm, enable it via [Corepack](https://nodejs.org/api/corepack.html): `corepack enable`.
+
 ```sh
 git clone https://github.com/ZRktty/accent-folding.git
 cd accent-folding
@@ -34,8 +36,8 @@ Open an issue describing the use case before implementing anything large. For sm
 ## Code style
 
 - No build step — plain JavaScript.
-- No dependencies.
-- Keep it small. The library is 2.7 kB gzipped; changes that balloon the size need strong justification.
+- Avoid adding dependencies. The library ships with zero runtime dependencies.
+- Keep it small. Run `pnpm size` to check bundle size; changes that significantly increase it need strong justification.
 
 ## License
 


### PR DESCRIPTION
Adds standard community health files:

- **`CONTRIBUTING.md`** — setup instructions, test commands, PR workflow, bug/feature reporting, code style guidelines, and licensing note
- **`CODE_OF_CONDUCT.md`** — community standards for participation
- **`AGENTS.md`** — agent instructions for AI coding assistants (key constraints, project layout, commands, branch/PR workflow, testing guidelines)