### PR TITLE
feat: add matchPositions() — framework-agnostic highlight primitive (closes #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Searching "cafe" should find "café". Highlighting "lo" in "López" should show `<b>Ló</b>pez` — not stripped text.
 
-`accent-folding` is the only library that solves both: accent-insensitive matching that returns the **original accented string** with HTML markup around matches. Zero dependencies. 2.7 kB gzipped.
+`accent-folding` is the only library that solves both: accent-insensitive matching that returns the **original accented string** with HTML markup around matches — or raw index positions for React, React Native, PDF, canvas, and any environment where HTML strings don't belong. Zero dependencies. 2.7 kB gzipped.
 
 ## Installation
 
@@ -37,20 +37,45 @@ yarn add accent-folding
 Full type declarations are included. No `@types/` package needed.
 
 ```ts
-import AccentFolding, { type AccentMap } from 'accent-folding';
+import AccentFolding, { type AccentMap, type MatchPosition } from 'accent-folding';
 
 const af = new AccentFolding();
 
 const replaced: string = af.replace('café');
+const positions: MatchPosition[] = af.matchPositions('López', 'lo');
 const highlighted: string = af.highlightMatch('López', 'lo');
 const highlightedMark: string = af.highlightMatch('López', 'lo', 'mark');
 
 // Custom accent map with typed argument
 const customMap: AccentMap = { ö: 'oe', ü: 'ue' };
 const afCustom = new AccentFolding(customMap);
+
+// Type your own rendering helper
+function renderParts(text: string, positions: MatchPosition[]) { ... }
 ```
 
 ## Public Methods
+
+### `matchPositions`
+
+Returns an array of `{ start, end }` index pairs for every accent-insensitive match of `fragment` in `str`. `end` is exclusive — pass directly to `str.slice(start, end)`.
+
+```js
+import AccentFolding from 'accent-folding';
+
+const af = new AccentFolding();
+
+af.matchPositions('Fulanilo López', 'lo');
+// → [{ start: 6, end: 8 }, { start: 9, end: 11 }]
+
+af.matchPositions('Straße', 'ss');
+// → [{ start: 4, end: 5 }]  ß treated as ss, position points back to ß
+
+af.matchPositions('Hello World', 'xyz');
+// → []
+```
+
+This is the framework-agnostic primitive. Use it when you need to control rendering yourself — React without `dangerouslySetInnerHTML`, React Native, PDF generation, canvas, terminal ANSI codes, and so on.
 
 ### `highlightMatch`
 
@@ -138,7 +163,9 @@ input.addEventListener('input', () => {
 });
 ```
 
-### React
+### React — with `matchPositions` (recommended)
+
+Use `matchPositions` to build real React elements — no `dangerouslySetInnerHTML`, no ESLint warnings, works with concurrent mode and React Server Components.
 
 ```jsx
 import { useState } from 'react';
@@ -146,6 +173,25 @@ import AccentFolding from 'accent-folding';
 
 const af = new AccentFolding();
 const names = ['López', 'Müller', 'Björk', 'Ñoño', 'García', 'Renée'];
+
+function Highlight({ text, query }) {
+	const positions = af.matchPositions(text, query);
+	if (!positions.length) return <span>{text}</span>;
+
+	const parts = [];
+	let last = 0;
+	for (const { start, end } of positions) {
+		if (start > last) parts.push(text.slice(last, start));
+		parts.push(
+			<mark key={start} className="bg-yellow-200 rounded px-0.5 font-semibold">
+				{text.slice(start, end)}
+			</mark>
+		);
+		last = end;
+	}
+	parts.push(text.slice(last));
+	return <span>{parts}</span>;
+}
 
 export default function AccentSearch() {
 	const [query, setQuery] = useState('');
@@ -165,12 +211,9 @@ export default function AccentSearch() {
 			/>
 			<ul>
 				{matches.map((name) => (
-					<li
-						key={name}
-						dangerouslySetInnerHTML={{
-							__html: query ? af.highlightMatch(name, query) : name,
-						}}
-					/>
+					<li key={name}>
+						<Highlight text={name} query={query} />
+					</li>
 				))}
 			</ul>
 		</div>
@@ -178,7 +221,40 @@ export default function AccentSearch() {
 }
 ```
 
-`dangerouslySetInnerHTML` is safe here because `names` is app-controlled data. Never use it with strings from untrusted external input.
+### React Native
+
+`highlightMatch` is useless in React Native — there is no DOM. `matchPositions` is the only way to highlight accented text in a native app.
+
+```jsx
+import { Text, StyleSheet } from 'react-native';
+import AccentFolding from 'accent-folding';
+
+const af = new AccentFolding();
+
+function Highlight({ text, query }) {
+	const positions = af.matchPositions(text, query);
+	if (!positions.length) return <Text>{text}</Text>;
+
+	const parts = [];
+	let last = 0;
+	for (const { start, end } of positions) {
+		if (start > last)
+			parts.push(<Text key={`t-${last}`}>{text.slice(last, start)}</Text>);
+		parts.push(
+			<Text key={`h-${start}`} style={styles.highlight}>
+				{text.slice(start, end)}
+			</Text>
+		);
+		last = end;
+	}
+	parts.push(<Text key="tail">{text.slice(last)}</Text>);
+	return <Text>{parts}</Text>;
+}
+
+const styles = StyleSheet.create({
+	highlight: { fontWeight: 'bold', backgroundColor: '#fef08a' },
+});
+```
 
 A full React + TypeScript demo (Vite, typed `AccentMap`, search highlight, custom map showcase) is available in [`demo/`](demo/). Run it with:
 
@@ -235,6 +311,7 @@ accentFoldedHighlight('Fulanilo López', 'lo', 'strong'); // --> "Fulani<strong>
 | --------------------------- | ---------------------------------- | ------------------------------------------------------------------------------- |
 | Status                      | ❌ Archived Nov 2024               | ✅ Actively maintained                                                          |
 | `highlightMatch()`          | ❌ No                              | ✅ Unique — wraps matches in HTML while preserving original accented characters |
+| `matchPositions()`          | ❌ No                              | ✅ Framework-agnostic — works in React, React Native, PDF, canvas, terminal     |
 | NFC/NFD normalization       | ❌ NFD input produces wrong output | ✅ Handles both automatically                                                   |
 | Result caching              | ❌ No                              | ✅ Yes — repeated calls with the same input are cached                          |
 | Test coverage               | ❌ Not reported                    | ✅ 100% line + branch coverage                                                  |

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>accent-folding · TypeScript demo</title>
+		<title>accent-folding</title>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/demo/npm-icon.svg
+++ b/demo/npm-icon.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="2"><g fill-rule="nonzero"><path d="M10.999 500.999v-490h490v490h-490z" fill="#c12127"/><path d="M102.874 102.874h306.25v306.25h-61.25v-245h-91.875v245H102.874v-306.25z" fill="#fff"/></g></svg>

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,9 +14,11 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "tailwindcss": "^4.3.0",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"
   }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -75,17 +75,14 @@ export default function App() {
 							className="opacity-70 hover:opacity-100 transition-opacity"
 						>
 							<svg
-								viewBox="0 0 18 7"
-								width="40"
-								height="16"
+								viewBox="0 0 24 24"
+								width="20"
+								height="20"
 								aria-label="npm"
 								role="img"
+								fill="#CB3837"
 							>
-								<path fill="#CB3837" d="M0 0h18v7H0z" />
-								<path
-									fill="#fff"
-									d="M3 1H1v5h2V2h1v4h1V1H3zm4 0H5v5h2V2h2v3H8v1h1V1H7zm5 0H9v5h4V1zm-2 1h2v3h-1V2h-1v2h1v1h-1V2zm4-1h2v5h-1V2h-1v4h-1V1h1z"
-								/>
+								<path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.568h-3.94l.01-9.635-5.444-.012-.01 9.648H5.12z" />
 							</svg>
 						</a>
 						<a

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,5 +1,8 @@
 import { useState } from 'react';
-import AccentFolding, { type AccentMap } from 'accent-folding';
+import AccentFolding, {
+	type AccentMap,
+	type MatchPosition,
+} from 'accent-folding';
 
 // Custom map typed with AccentMap — triggers a TS error if keys/values aren't strings
 const germanMap: AccentMap = { ö: 'oe', ü: 'ue', ä: 'ae', ß: 'ss' };
@@ -20,6 +23,30 @@ const NAMES = [
 ];
 
 type WrapTag = 'b' | 'strong' | 'mark' | 'span';
+
+function Highlight({ text, query }: { text: string; query: string }) {
+	const positions: MatchPosition[] = query
+		? af.matchPositions(text, query)
+		: [];
+	if (!positions.length) return <span>{text}</span>;
+
+	const parts: React.ReactNode[] = [];
+	let last = 0;
+	for (const { start, end } of positions) {
+		if (start > last) parts.push(text.slice(last, start));
+		parts.push(
+			<mark
+				key={start}
+				className="bg-yellow-200 text-yellow-900 rounded px-0.5 font-semibold not-italic"
+			>
+				{text.slice(start, end)}
+			</mark>
+		);
+		last = end;
+	}
+	parts.push(text.slice(last));
+	return <span>{parts}</span>;
+}
 
 function matches(name: string, query: string): boolean {
 	return af
@@ -128,18 +155,129 @@ export default function App() {
 				</table>
 			</section>
 
+			<section className="card">
+				<h2>matchPositions() — real React elements, Tailwind styling</h2>
+				<p className="subtitle">
+					Same accent-insensitive search, but instead of injecting raw HTML you
+					get <code>[&#123; start, end &#125;]</code> pairs and own the render
+					entirely. No <code>dangerouslySetInnerHTML</code>.
+				</p>
+
+				{/* Live search */}
+				<input
+					type="text"
+					value={query}
+					onChange={(e) => setQuery(e.target.value)}
+					placeholder="Search names…"
+					autoComplete="off"
+				/>
+				<ul className="mt-2 space-y-1">
+					{(query ? NAMES.filter((n) => matches(n, query)) : NAMES).map(
+						(name) => (
+							<li
+								key={name}
+								className="px-3 py-2 rounded-lg border border-gray-100 bg-gray-50 text-sm font-mono"
+							>
+								<Highlight text={name} query={query} />
+							</li>
+						)
+					)}
+				</ul>
+
+				{/* Before / After comparison */}
+				<div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+					{/* Before */}
+					<div className="rounded-xl border border-red-200 bg-red-50 p-4">
+						<p className="mb-2 text-xs font-semibold uppercase tracking-wide text-red-500">
+							Before — highlightMatch()
+						</p>
+						<pre className="overflow-x-auto rounded bg-white p-3 text-xs leading-relaxed text-gray-700 border border-red-100">{`<li dangerouslySetInnerHTML={{
+  __html: af.highlightMatch(name, query)
+}} />`}</pre>
+						<ul className="mt-3 space-y-1 text-xs text-red-700">
+							<li>
+								✗ ESLint flags{' '}
+								<code className="font-mono">dangerouslySetInnerHTML</code>
+							</li>
+							<li>✗ Senior devs reject it in code review</li>
+							<li>
+								✗ Can't attach event handlers to the{' '}
+								<code className="font-mono">&lt;b&gt;</code>
+							</li>
+							<li>✗ Useless in React Native — no DOM</li>
+							<li>✗ Useless in PDF libs, canvas, terminal</li>
+						</ul>
+					</div>
+
+					{/* After */}
+					<div className="rounded-xl border border-green-200 bg-green-50 p-4">
+						<p className="mb-2 text-xs font-semibold uppercase tracking-wide text-green-600">
+							After — matchPositions()
+						</p>
+						<pre className="overflow-x-auto rounded bg-white p-3 text-xs leading-relaxed text-gray-700 border border-green-100">{`const pos = af.matchPositions(text, query);
+// render <mark> with any Tailwind class you want
+<mark className="bg-yellow-200 text-yellow-900
+  rounded px-0.5 font-semibold">
+  {text.slice(start, end)}
+</mark>`}</pre>
+						<ul className="mt-3 space-y-1 text-xs text-green-700">
+							<li>✓ Real React elements, zero ESLint warnings</li>
+							<li>✓ Full Tailwind / CSS-in-JS / Framer Motion control</li>
+							<li>
+								✓ Works in React Native{' '}
+								<code className="font-mono">&lt;Text&gt;</code>
+							</li>
+							<li>✓ Works in PDF libs, canvas pixel offsets, ANSI terminal</li>
+							<li>✓ Stable React keys, compatible with concurrent mode</li>
+						</ul>
+					</div>
+				</div>
+
+				{/* Code snippet */}
+				<div className="mt-5">
+					<p className="mb-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+						The Highlight component used above
+					</p>
+					<pre className="overflow-x-auto rounded-lg bg-gray-900 p-4 text-xs leading-relaxed text-gray-100">{`function Highlight({ text, query }) {
+  const positions = af.matchPositions(text, query);
+  if (!positions.length) return <span>{text}</span>;
+
+  const parts = [];
+  let last = 0;
+  for (const { start, end } of positions) {
+    if (start > last) parts.push(text.slice(last, start));
+    parts.push(
+      <mark
+        key={start}
+        className="bg-yellow-200 text-yellow-900 rounded px-0.5 font-semibold"
+      >
+        {text.slice(start, end)}
+      </mark>
+    );
+    last = end;
+  }
+  parts.push(text.slice(last));
+  return <span>{parts}</span>;
+}`}</pre>
+				</div>
+			</section>
+
 			<section className="card types-card">
 				<h2>TypeScript types at work</h2>
-				<pre>{`import AccentFolding, { type AccentMap } from 'accent-folding';
+				<pre>{`import AccentFolding, { type AccentMap, type MatchPosition } from 'accent-folding';
 
 const af = new AccentFolding();
 
-const replaced:    string = af.replace('café');
-const highlighted: string = af.highlightMatch('López', 'lo');
-const withTag:     string = af.highlightMatch('López', 'lo', 'mark');
+const replaced:    string          = af.replace('café');
+const positions:   MatchPosition[] = af.matchPositions('López', 'lo');
+const highlighted: string          = af.highlightMatch('López', 'lo');
+const withTag:     string          = af.highlightMatch('López', 'lo', 'mark');
 
 const myMap: AccentMap = { ö: 'oe', ü: 'ue' };
 const afCustom = new AccentFolding(myMap);
+
+// Type your own rendering helper:
+function renderParts(text: string, pos: MatchPosition[]) { ... }
 
 // These would be TS errors:
 // af.replace(42)              → Argument of type 'number' is not assignable to 'string'

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import npmIcon from '../npm-icon.svg';
 import AccentFolding, {
 	type AccentMap,
 	type MatchPosition,
@@ -74,16 +75,7 @@ export default function App() {
 							title="View on npm"
 							className="opacity-70 hover:opacity-100 transition-opacity"
 						>
-							<svg
-								viewBox="0 0 24 24"
-								width="20"
-								height="20"
-								aria-label="npm"
-								role="img"
-								fill="#CB3837"
-							>
-								<path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.568h-3.94l.01-9.635-5.444-.012-.01 9.648H5.12z" />
-							</svg>
+							<img src={npmIcon} alt="npm" width={20} height={20} />
 						</a>
 						<a
 							href="https://github.com/ZRktty/accent-folding"

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -64,11 +64,53 @@ export default function App() {
 	return (
 		<div className="page">
 			<header>
-				<h1>accent-folding · TypeScript demo</h1>
+				<div className="flex flex-wrap items-center gap-3 mb-1">
+					<h1 style={{ margin: 0 }}>accent-folding</h1>
+					<div className="flex items-center gap-2">
+						<a
+							href="https://www.npmjs.com/package/accent-folding"
+							target="_blank"
+							rel="noopener noreferrer"
+							title="View on npm"
+							className="opacity-70 hover:opacity-100 transition-opacity"
+						>
+							<svg
+								viewBox="0 0 18 7"
+								width="40"
+								height="16"
+								aria-label="npm"
+								role="img"
+							>
+								<path fill="#CB3837" d="M0 0h18v7H0z" />
+								<path
+									fill="#fff"
+									d="M3 1H1v5h2V2h1v4h1V1H3zm4 0H5v5h2V2h2v3H8v1h1V1H7zm5 0H9v5h4V1zm-2 1h2v3h-1V2h-1v2h1v1h-1V2zm4-1h2v5h-1V2h-1v4h-1V1h1z"
+								/>
+							</svg>
+						</a>
+						<a
+							href="https://github.com/ZRktty/accent-folding"
+							target="_blank"
+							rel="noopener noreferrer"
+							title="View on GitHub"
+							className="opacity-70 hover:opacity-100 transition-opacity text-gray-700"
+						>
+							<svg
+								viewBox="0 0 16 16"
+								width="20"
+								height="20"
+								aria-label="GitHub"
+								role="img"
+								fill="currentColor"
+							>
+								<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+							</svg>
+						</a>
+					</div>
+				</div>
 				<p className="subtitle">
-					Real TypeScript consumer — imports <code>AccentFolding</code> and{' '}
-					<code>AccentMap</code> from the local package. Try <strong>lo</strong>
-					, <strong>mu</strong>, <strong>gar</strong>, or <strong>bj</strong>.
+					Accent-insensitive search and highlight. Try <strong>lo</strong>,{' '}
+					<strong>mu</strong>, <strong>gar</strong>, or <strong>bj</strong>.
 				</p>
 			</header>
 
@@ -132,7 +174,7 @@ export default function App() {
 				<h2>Custom AccentMap (German)</h2>
 				<p className="subtitle">
 					<code>AccentMap</code> typed as{' '}
-					<code>{'Record<string, string>'}</code> — afGerman uses{' '}
+					<code>{'Record<string, string>'}</code> — <code>afGerman</code> uses{' '}
 					<code>ö→oe, ü→ue, ä→ae, ß→ss</code>
 				</p>
 				<table>

--- a/demo/src/assets.d.ts
+++ b/demo/src/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+	const src: string;
+	export default src;
+}

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -1,3 +1,5 @@
+@import 'tailwindcss';
+
 *,
 *::before,
 *::after {

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-	plugins: [react()],
+	plugins: [react(), tailwindcss()],
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,14 @@
 export type AccentMap = Record<string, string>;
 
+export interface MatchPosition {
+	start: number;
+	end: number;
+}
+
 export default class AccentFolding {
 	constructor(newMap?: AccentMap | null);
 	replace(text: string): string;
+	matchPositions(str: string, fragment: string): MatchPosition[];
 	highlightMatch(str: string, fragment: string, wrapTag?: string): string;
 	static convertAccentMapToArray(accentMap: AccentMap): Array<[string, string]>;
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "src/"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=18.20"
   },
   "devEngines": {
     "runtime": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,16 +16,16 @@ importers:
         version: 10.0.1(semantic-release@25.0.3(typescript@5.9.3))
       '@size-limit/preset-small-lib':
         specifier: ^12.1.0
-        version: 12.1.0(size-limit@12.1.0)
+        version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.7)
       eslint:
         specifier: ^10.4.0
-        version: 10.4.0
+        version: 10.4.0(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.4.0)
+        version: 10.1.8(eslint@10.4.0(jiti@2.7.0))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -46,13 +46,13 @@ importers:
         version: 25.0.3(typescript@5.9.3)
       size-limit:
         specifier: ^12.1.0
-        version: 12.1.0
+        version: 12.1.0(jiti@2.7.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@vitest/coverage-v8@4.1.7)(vite@7.3.3(yaml@2.9.0))
+        version: 4.1.7(@vitest/coverage-v8@4.1.7)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
 
   demo:
     dependencies:
@@ -66,6 +66,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       '@types/react':
         specifier: ^18.3.1
         version: 18.3.29
@@ -74,13 +77,16 @@ importers:
         version: 18.3.7(@types/react@18.3.29)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(yaml@2.9.0))
+        version: 4.7.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       vite:
         specifier: ^6.3.5
-        version: 6.4.2(yaml@2.9.0)
+        version: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
 packages:
 
@@ -1007,6 +1013,100 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1357,6 +1457,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -1379,6 +1483,10 @@ packages:
 
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
+  enhanced-resolve@5.22.0:
+    resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
+    engines: {node: '>=10.13.0'}
 
   env-ci@11.0.0:
     resolution: {integrity: sha512-apikxMgkipkgTvMdRT9MNqWx5VLOci79F4VBd7Op/7OPjjoanjdAvn6fglMCCEf/1bAh8eOiuEVCUs4V3qP3nQ==}
@@ -1795,6 +1903,10 @@ packages:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -1842,6 +1954,80 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -2514,6 +2700,13 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
 
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
@@ -3219,9 +3412,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.4.0
+      eslint: 10.4.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -3532,23 +3725,91 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@size-limit/esbuild@12.1.0(size-limit@12.1.0)':
+  '@size-limit/esbuild@12.1.0(size-limit@12.1.0(jiti@2.7.0))':
     dependencies:
       esbuild: 0.28.0
       nanoid: 5.1.11
-      size-limit: 12.1.0
+      size-limit: 12.1.0(jiti@2.7.0)
 
-  '@size-limit/file@12.1.0(size-limit@12.1.0)':
+  '@size-limit/file@12.1.0(size-limit@12.1.0(jiti@2.7.0))':
     dependencies:
-      size-limit: 12.1.0
+      size-limit: 12.1.0(jiti@2.7.0)
 
-  '@size-limit/preset-small-lib@12.1.0(size-limit@12.1.0)':
+  '@size-limit/preset-small-lib@12.1.0(size-limit@12.1.0(jiti@2.7.0))':
     dependencies:
-      '@size-limit/esbuild': 12.1.0(size-limit@12.1.0)
-      '@size-limit/file': 12.1.0(size-limit@12.1.0)
-      size-limit: 12.1.0
+      '@size-limit/esbuild': 12.1.0(size-limit@12.1.0(jiti@2.7.0))
+      '@size-limit/file': 12.1.0(size-limit@12.1.0(jiti@2.7.0))
+      size-limit: 12.1.0(jiti@2.7.0)
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.22.0
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/vite@4.3.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3601,7 +3862,7 @@ snapshots:
 
   '@types/semver@7.5.8': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -3609,7 +3870,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(yaml@2.9.0)
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3625,7 +3886,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@vitest/coverage-v8@4.1.7)(vite@7.3.3(yaml@2.9.0))
+      vitest: 4.1.7(@vitest/coverage-v8@4.1.7)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -3636,13 +3897,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@7.3.3(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(yaml@2.9.0)
+      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -3899,6 +4160,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  detect-libc@2.1.2: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -3918,6 +4181,11 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emojilib@2.4.0: {}
+
+  enhanced-resolve@5.22.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   env-ci@11.0.0:
     dependencies:
@@ -4036,9 +4304,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.4.0):
+  eslint-config-prettier@10.1.8(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.0
+      eslint: 10.4.0(jiti@2.7.0)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -4051,9 +4319,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.4.0:
+  eslint@10.4.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.6.0
@@ -4083,6 +4351,8 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4383,6 +4653,8 @@ snapshots:
 
   java-properties@1.0.2: {}
 
+  jiti@2.7.0: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -4421,6 +4693,55 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -4922,13 +5243,15 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  size-limit@12.1.0:
+  size-limit@12.1.0(jiti@2.7.0):
     dependencies:
       bytes-iec: 3.1.1
       lilconfig: 3.1.3
       nanospinner: 1.2.2
       picocolors: 1.1.1
       tinyglobby: 0.2.16
+    optionalDependencies:
+      jiti: 2.7.0
 
   skin-tone@2.0.0:
     dependencies:
@@ -5042,6 +5365,10 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tailwindcss@4.3.0: {}
+
+  tapable@2.3.3: {}
+
   temp-dir@3.0.0: {}
 
   tempy@3.1.0:
@@ -5145,7 +5472,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@6.4.2(yaml@2.9.0):
+  vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5155,9 +5482,11 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
       yaml: 2.9.0
 
-  vite@7.3.3(yaml@2.9.0):
+  vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5167,12 +5496,14 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
       yaml: 2.9.0
 
-  vitest@4.1.7(@vitest/coverage-v8@4.1.7)(vite@7.3.3(yaml@2.9.0)):
+  vitest@4.1.7(@vitest/coverage-v8@4.1.7)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@7.3.3(yaml@2.9.0))
+      '@vitest/mocker': 4.1.7(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -5189,7 +5520,7 @@ snapshots:
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.3(yaml@2.9.0)
+      vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)

--- a/src/accentFolding.js
+++ b/src/accentFolding.js
@@ -1,6 +1,4 @@
-import { createRequire } from 'module';
-const require = createRequire(import.meta.url);
-const defaultAccentMap = require('./accentMap.json');
+import defaultAccentMap from './accentMap.json' with { type: 'json' };
 
 class AccentFolding {
 	#cache;

--- a/src/accentFolding.js
+++ b/src/accentFolding.js
@@ -95,10 +95,10 @@ class AccentFolding {
 	 * // → []
 	 */
 	matchPositions(str, fragment) {
-		if (!fragment) return [];
 		if (typeof str !== 'string' || typeof fragment !== 'string') {
 			throw new TypeError('Both str and fragment must be strings');
 		}
+		if (!fragment) return [];
 		return this.#findMatchPositions(str.normalize('NFC'), fragment);
 	}
 

--- a/src/accentFolding.js
+++ b/src/accentFolding.js
@@ -72,6 +72,30 @@ class AccentFolding {
 		return positions;
 	}
 
+	/**
+	 * Returns the start/end index pairs of every accent-insensitive match of
+	 * `fragment` in `str`. Indices refer to the original string — `end` is
+	 * exclusive, so `str.slice(start, end)` yields the matched substring.
+	 *
+	 * Use this instead of `highlightMatch` whenever you need to own the
+	 * rendering: React elements, React Native `<Text>`, PDF primitives,
+	 * terminal ANSI codes, canvas pixel offsets, etc.
+	 *
+	 * @param {string} str - The string to search in.
+	 * @param {string} fragment - The search query (accent-insensitive, case-insensitive).
+	 * @returns {{ start: number, end: number }[]} Matched ranges, or `[]` when there is no match.
+	 * @throws {TypeError} If either argument is not a string.
+	 *
+	 * @example
+	 * af.matchPositions('Fulanilo López', 'lo')
+	 * // → [{ start: 6, end: 8 }, { start: 9, end: 11 }]
+	 *
+	 * af.matchPositions('Straße', 'ss')
+	 * // → [{ start: 4, end: 5 }]  — ß folds to ss; position maps back to ß
+	 *
+	 * af.matchPositions('Hello World', 'xyz')
+	 * // → []
+	 */
 	matchPositions(str, fragment) {
 		if (!fragment) return [];
 		if (typeof str !== 'string' || typeof fragment !== 'string') {

--- a/src/accentFolding.js
+++ b/src/accentFolding.js
@@ -38,6 +38,48 @@ class AccentFolding {
 		return this.#fold(text);
 	}
 
+	#findMatchPositions(strNFC, fragment) {
+		const offsets = [];
+		let foldedStr = '';
+		for (const char of [...strNFC]) {
+			offsets.push(foldedStr.length);
+			foldedStr += this.#accentMap.get(char) ?? char;
+		}
+		offsets.push(foldedStr.length);
+
+		const escapedFragment = fragment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		const fragmentFolded = this.#fold(escapedFragment).toLowerCase();
+		const re = new RegExp(fragmentFolded, 'g');
+
+		const positions = [];
+		let lastOriginalIndex = 0;
+
+		foldedStr.toLowerCase().replace(re, (match, foldedIndex) => {
+			const foldedEnd = foldedIndex + match.length;
+			const origStart = offsets.findIndex(
+				(_, i) => offsets[i] <= foldedIndex && foldedIndex < offsets[i + 1]
+			);
+			const origEnd = offsets.findIndex(
+				(_, i) => offsets[i] <= foldedEnd && foldedEnd <= offsets[i + 1]
+			);
+
+			if (origStart < 0 || origEnd < 0 || origStart < lastOriginalIndex) return;
+
+			positions.push({ start: origStart, end: origEnd + 1 });
+			lastOriginalIndex = origEnd + 1;
+		});
+
+		return positions;
+	}
+
+	matchPositions(str, fragment) {
+		if (!fragment) return [];
+		if (typeof str !== 'string' || typeof fragment !== 'string') {
+			throw new TypeError('Both str and fragment must be strings');
+		}
+		return this.#findMatchPositions(str.normalize('NFC'), fragment);
+	}
+
 	highlightMatch(str, fragment, wrapTag = 'b') {
 		try {
 			if (!fragment) return str;
@@ -52,49 +94,19 @@ class AccentFolding {
 			}
 
 			const strNFC = str.normalize('NFC');
+			const positions = this.#findMatchPositions(strNFC, fragment);
 
-			// Build a folded string with an offset table that maps each position
-			// in the folded string back to the corresponding original character index.
-			// This handles multi-character expansions (e.g. ß → ss, æ → ae).
-			const chars = [...strNFC];
-			const offsets = []; // offsets[i] = start position in foldedStr for chars[i]
-			let foldedStr = '';
-			for (const char of chars) {
-				offsets.push(foldedStr.length);
-				foldedStr += this.#accentMap.get(char) ?? char;
-			}
-			offsets.push(foldedStr.length); // sentinel
+			if (!positions.length) return str;
 
-			const escapedFragment = fragment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-			const fragmentFolded = this.#fold(escapedFragment).toLowerCase();
-
-			const re = new RegExp(fragmentFolded, 'g');
 			let result = '';
-			let lastOriginalIndex = 0;
-			let hasMatch = false;
-
-			foldedStr.toLowerCase().replace(re, (match, foldedIndex) => {
-				// Map folded indices back to original character indices.
-				const foldedEnd = foldedIndex + match.length;
-				const origStart = offsets.findIndex(
-					(_, i) => offsets[i] <= foldedIndex && foldedIndex < offsets[i + 1]
-				);
-				const origEnd = offsets.findIndex(
-					(_, i) => offsets[i] <= foldedEnd && foldedEnd <= offsets[i + 1]
-				);
-
-				if (origStart < 0 || origEnd < 0 || origStart < lastOriginalIndex)
-					return;
-
-				hasMatch = true;
-				result += this.#escapeHtml(strNFC.slice(lastOriginalIndex, origStart));
-				result += `<${wrapTag}>${this.#escapeHtml(strNFC.slice(origStart, origEnd + 1))}</${wrapTag}>`;
-				lastOriginalIndex = origEnd + 1;
-			});
-
-			result += this.#escapeHtml(strNFC.slice(lastOriginalIndex));
-
-			return hasMatch ? result : str;
+			let last = 0;
+			for (const { start, end } of positions) {
+				result += this.#escapeHtml(strNFC.slice(last, start));
+				result += `<${wrapTag}>${this.#escapeHtml(strNFC.slice(start, end))}</${wrapTag}>`;
+				last = end;
+			}
+			result += this.#escapeHtml(strNFC.slice(last));
+			return result;
 		} catch (error) {
 			console.error('Error in highlightMatch:', error.message);
 			throw error;

--- a/src/accentFolding.js.test.js
+++ b/src/accentFolding.js.test.js
@@ -9,6 +9,78 @@ describe('AccentFolding', () => {
 		accentFolder = new AccentFolding();
 	});
 
+	describe('matchPositions', () => {
+		it('returns [] for empty fragment', () => {
+			expect(accentFolder.matchPositions('Hello', '')).toEqual([]);
+		});
+
+		it('returns [] when no match', () => {
+			expect(accentFolder.matchPositions('Hello World', 'xyz')).toEqual([]);
+		});
+
+		it('returns [] for empty string', () => {
+			expect(accentFolder.matchPositions('', 'lo')).toEqual([]);
+		});
+
+		it('throws TypeError for non-string inputs', () => {
+			expect(() => accentFolder.matchPositions(123, 'lo')).toThrow(TypeError);
+			expect(() => accentFolder.matchPositions('text', 123)).toThrow(TypeError);
+		});
+
+		it('finds accent-insensitive matches and returns correct positions', () => {
+			expect(accentFolder.matchPositions('Fulanilo López', 'lo')).toEqual([
+				{ start: 6, end: 8 },
+				{ start: 9, end: 11 },
+			]);
+		});
+
+		it('is case insensitive', () => {
+			expect(accentFolder.matchPositions('FULANILO LÓPEZ', 'lo')).toEqual([
+				{ start: 6, end: 8 },
+				{ start: 9, end: 11 },
+			]);
+		});
+
+		it('handles multi-character folding: ß matched by ss', () => {
+			expect(accentFolder.matchPositions('Straße', 'ss')).toEqual([
+				{ start: 4, end: 5 },
+			]);
+		});
+
+		it('handles multi-character folding: æ matched by ae', () => {
+			expect(accentFolder.matchPositions('encyclopædia', 'ae')).toEqual([
+				{ start: 8, end: 9 },
+			]);
+		});
+
+		it('positions slice back to the original matched text', () => {
+			const text = 'Fulanilo López';
+			const positions = accentFolder.matchPositions(text, 'lo');
+			expect(text.slice(positions[0].start, positions[0].end)).toBe('lo');
+			expect(text.slice(positions[1].start, positions[1].end)).toBe('Ló');
+		});
+
+		it('positions slice back the correct text for ß', () => {
+			const text = 'Straße';
+			const [{ start, end }] = accentFolder.matchPositions(text, 'ss');
+			expect(text.slice(start, end)).toBe('ß');
+		});
+
+		it('handles multiple matches', () => {
+			const positions = accentFolder.matchPositions('lólá lòlã', 'la');
+			expect(positions).toEqual([
+				{ start: 2, end: 4 },
+				{ start: 7, end: 9 },
+			]);
+		});
+
+		it('handles special characters in fragment', () => {
+			expect(accentFolder.matchPositions('a+b=c', '+')).toEqual([
+				{ start: 1, end: 2 },
+			]);
+		});
+	});
+
 	describe('highlightMatch', () => {
 		it('should throw TypeError if str is not a string', () => {
 			expect(() => accentFolder.highlightMatch(123, 'test')).toThrow(TypeError);


### PR DESCRIPTION
## Summary

- Adds `matchPositions(str, fragment)` — returns `[{ start, end }]` index pairs for every accent-insensitive match, where `end` is exclusive (slice-style)
- Refactors `highlightMatch` to share a private `#findMatchPositions()` helper — no behaviour change, all existing tests pass
- Exports `MatchPosition` as a named TypeScript type with JSDoc
- Updates README with `matchPositions` API docs, React (no `dangerouslySetInnerHTML`) and React Native examples, and updated comparison table
- Demo: new section with live Tailwind-styled `Highlight` component, Before/After comparison card, and dark code block
- Fixes browser compatibility: replaces `createRequire` (Node-only) with `import ... with { type: 'json' }` so the package works in Vite and browsers
- Adds 11 new tests covering: empty inputs, no-match, TypeError, multi-char folding (ß/æ), case insensitivity, multiple matches, special characters, and slice correctness

## Why this matters

`highlightMatch()` returns an HTML string — useless outside a DOM. `matchPositions()` is the framework-agnostic primitive that works everywhere:

| Environment | Why `matchPositions` |
|---|---|
| **React** | Build real elements, no `dangerouslySetInnerHTML`, no ESLint warnings |
| **React Native** | No DOM exists — HTML strings literally can't be used |
| **PDF (react-pdf / pdfkit)** | PDF libs render primitives, not HTML |
| **Terminal / CLI** | Apply ANSI codes at exact positions |
| **Canvas / WebGL** | Need character offsets to draw highlight rectangles |

## Test plan

- [x] `pnpm test` — 753 tests, all passing
- [x] `pnpm build` (demo) — clean Vite production build
- [x] TypeScript — zero errors (`tsc --noEmit`)
- [x] `matchPositions` slices verified: `text.slice(start, end)` returns the exact matched substring including multi-char folded chars (ß, æ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)