### PR TITLE
feat: dual ESM + CJS build via tsup

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build
+        run: pnpm run build
+
       - name: Type check
         run: pnpm run type-check
 
@@ -39,6 +42,9 @@ jobs:
 
       - name: Run tests with coverage
         run: pnpm run coverage
+
+      - name: Run integration tests
+        run: pnpm run test:integration
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - run: pnpm audit --prod
+      - name: Build
+        run: pnpm run build
       - name: Release 🚀
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 .claude/
 demo/dist/
 package-lock.json
+dist/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Searching "cafe" should find "café". Highlighting "lo" in "López" should show `<b>Ló</b>pez` — not stripped text.
 
-`accent-folding` is the only library that solves both: accent-insensitive matching that returns the **original accented string** with HTML markup around matches — or raw index positions for React, React Native, PDF, canvas, and any environment where HTML strings don't belong. Zero dependencies. 2.7 kB gzipped.
+`accent-folding` is the only library that solves both: accent-insensitive matching that returns the **original accented string** with HTML markup around matches — or raw index positions for React, React Native, PDF, canvas, and any environment where HTML strings don't belong. Zero dependencies. ~2.4 kB gzipped. Ships as **dual ESM + CJS** — works in Node ESM, CommonJS, Jest (no transform config), Next.js pages router, and any bundler.
 
 ## Installation
 
@@ -30,6 +30,26 @@ or with yarn:
 
 ```shell
 yarn add accent-folding
+```
+
+## Module formats
+
+The package ships as a **dual ESM + CJS** build. No configuration needed — your toolchain picks the right format automatically:
+
+| Environment                                              | Format used                |
+| -------------------------------------------------------- | -------------------------- |
+| `import` / bundlers (Vite, webpack, Rollup)              | ESM (`dist/esm/index.js`)  |
+| `require()` / Jest (no transform) / Next.js pages router | CJS (`dist/cjs/index.cjs`) |
+
+```js
+// ESM
+import AccentFolding from 'accent-folding';
+
+// CommonJS
+const AccentFolding = require('accent-folding');
+
+const af = new AccentFolding();
+console.log(af.replace('café')); // → 'cafe'
 ```
 
 ## TypeScript
@@ -137,6 +157,24 @@ console.log(accentFolder.replace('✝illa')); // Outputs: tilla
 ```
 
 ## Real-World Examples
+
+### CommonJS (Jest, Next.js pages router)
+
+```js
+const AccentFolding = require('accent-folding');
+
+const af = new AccentFolding();
+const names = ['López', 'Müller', 'Björk', 'Ñoño'];
+
+// Filter and highlight — identical API to ESM
+const results = names
+	.filter((name) =>
+		af.replace(name).toLowerCase().includes(af.replace('lo').toLowerCase())
+	)
+	.map((name) => af.highlightMatch(name, 'lo'));
+
+console.log(results); // ['<b>Ló</b>pez']
+```
 
 ### Plain JS (browser)
 
@@ -267,9 +305,11 @@ cd demo && pnpm dev
 Node.js ≥18
 
 <details>
-<summary>Legacy usage (v1 CommonJS API)</summary>
+<summary>Legacy usage (v1 CommonJS API — accent-folding@1)</summary>
 
-Install with npm:
+v1 exported a single function (no class). If you need `require()` support with the **current** API, see the [Module formats](#module-formats) section above — v2+ ships dual ESM + CJS natively.
+
+Install v1:
 
 ```shell
 npm install accent-folding@1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,4 +15,4 @@
 
 - [x] Add TypeScript support
 - [ ] Add `attw` (`@arethetypeswrong/cli`) validation — blocked by upstream [fflate@0.8.3 crash](https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/262), revisit once a patched release ships
-- [ ] Add support for CommonJS
+- [x] Add support for CommonJS — dual ESM + CJS build via tsup; `require('accent-folding')` works in Jest, Next.js pages router, and any CJS toolchain

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,6 @@ export default [
 		},
 	},
 	{
-		ignores: ['dist/', '.idea', 'coverage/'],
+		ignores: ['dist/', 'demo/dist/', '.idea', 'coverage/'],
 	},
 ];

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-export { default } from './src/accentFolding.js';

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "type": "module",
   "sideEffects": false,
   "scripts": {
-    "build": "tsup && cp index.d.ts dist/esm/index.d.ts && cp index.d.ts dist/cjs/index.d.cts",
+    "build": "tsup && node scripts/copy-dts.mjs",
     "coverage": "vitest run --coverage",
     "format": "npx prettier --write .",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -2,17 +2,23 @@
   "name": "accent-folding",
   "version": "2.6.0",
   "description": "Accent-insensitive text matching with built-in search highlighting — the only library that returns original accented text with HTML markup around matches",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
-      "default": "./index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "files": [
-    "index.js",
-    "index.d.ts",
+    "dist/",
     "src/"
   ],
   "engines": {
@@ -26,13 +32,16 @@
     }
   },
   "type": "module",
+  "sideEffects": false,
   "scripts": {
+    "build": "tsup && cp index.d.ts dist/esm/index.d.ts && cp index.d.ts dist/cjs/index.d.cts",
     "coverage": "vitest run --coverage",
     "format": "npx prettier --write .",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "semantic-release": "semantic-release",
     "test": "vitest",
+    "test:integration": "node test/integration/esm.mjs && node test/integration/cjs.cjs",
     "type-check": "tsc",
     "docs": "pnpm dlx serve docs",
     "prepare": "husky",
@@ -48,12 +57,16 @@
   },
   "size-limit": [
     {
-      "path": "index.js",
+      "name": "ESM",
+      "path": "dist/esm/index.js",
       "limit": "4 kB",
-      "brotli": true,
-      "ignore": [
-        "module"
-      ]
+      "brotli": true
+    },
+    {
+      "name": "CJS",
+      "path": "dist/cjs/index.cjs",
+      "limit": "4 kB",
+      "brotli": true
     }
   ],
   "repository": {
@@ -112,6 +125,7 @@
     "publint": "^0.3.21",
     "semantic-release": "^25.0.3",
     "size-limit": "^12.1.0",
+    "tsup": "^8.5.1",
     "typescript": "^5.8.3",
     "vitest": "^4.1.7"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       size-limit:
         specifier: ^12.1.0
         version: 12.1.0(jiti@2.7.0)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -1298,9 +1301,19 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   bytes-iec@3.1.1:
     resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1328,6 +1341,10 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -1374,11 +1391,22 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
@@ -1672,6 +1700,9 @@ packages:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -1907,6 +1938,10 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -2049,6 +2084,10 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
 
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
     engines: {node: '>=4'}
@@ -2151,6 +2190,9 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -2423,9 +2465,34 @@ packages:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -2494,6 +2561,10 @@ packages:
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   registry-auth-token@5.0.2:
     resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
@@ -2603,6 +2674,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   spawn-error-forwarder@1.0.0:
     resolution: {integrity: sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==}
 
@@ -2681,6 +2756,11 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   super-regex@1.0.0:
     resolution: {integrity: sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==}
     engines: {node: '>=18'}
@@ -2733,6 +2813,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.2.2:
     resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
@@ -2752,6 +2835,32 @@ packages:
   traverse@0.6.8:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
     engines: {node: '>= 0.4'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
@@ -2785,6 +2894,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   uglify-js@3.19.2:
     resolution: {integrity: sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==}
@@ -4014,7 +4126,14 @@ snapshots:
       node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
   bytes-iec@3.1.1: {}
+
+  cac@6.7.14: {}
 
   callsites@3.1.0: {}
 
@@ -4036,6 +4155,10 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
 
   clean-stack@2.2.0: {}
 
@@ -4091,15 +4214,21 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@4.1.1: {}
+
   compare-func@2.0.0:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
+  confbox@0.1.8: {}
+
   config-chain@1.1.13:
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
+
+  consola@3.4.2: {}
 
   content-type@2.0.0: {}
 
@@ -4467,6 +4596,12 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.0.0
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.4
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
@@ -4655,6 +4790,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -4771,6 +4908,8 @@ snapshots:
       pify: 3.0.0
       strip-bom: 3.0.0
 
+  load-tsconfig@0.2.5: {}
+
   locate-path@2.0.0:
     dependencies:
       p-locate: 2.0.0
@@ -4863,6 +5002,13 @@ snapshots:
       brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
 
   mri@1.2.0: {}
 
@@ -5038,10 +5184,26 @@ snapshots:
 
   pify@3.0.0: {}
 
+  pirates@4.0.7: {}
+
   pkg-conf@2.1.0:
     dependencies:
       find-up: 2.1.0
       load-json-file: 4.0.0
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.7.0
+      postcss: 8.5.15
+      yaml: 2.9.0
 
   postcss@8.5.15:
     dependencies:
@@ -5126,6 +5288,8 @@ snapshots:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
+
+  readdirp@4.1.2: {}
 
   registry-auth-token@5.0.2:
     dependencies:
@@ -5271,6 +5435,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   spawn-error-forwarder@1.0.0: {}
 
   spdx-correct@3.2.0:
@@ -5345,6 +5511,16 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
   super-regex@1.0.0:
     dependencies:
       function-timeout: 1.0.2
@@ -5397,6 +5573,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
@@ -5411,6 +5589,38 @@ snapshots:
       is-number: 7.0.0
 
   traverse@0.6.8: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(yaml@2.9.0)
+      resolve-from: 5.0.0
+      rollup: 4.60.4
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.15
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tunnel@0.0.6: {}
 
@@ -5431,6 +5641,8 @@ snapshots:
       tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
 
   uglify-js@3.19.2:
     optional: true

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -9,7 +9,8 @@ module.exports = {
 			'@semantic-release/git',
 			{
 				assets: ['package.json'],
-				message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+				message:
+					'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
 			},
 		],
 	],

--- a/scripts/copy-dts.mjs
+++ b/scripts/copy-dts.mjs
@@ -1,0 +1,4 @@
+import { copyFileSync } from 'node:fs';
+
+copyFileSync('index.d.ts', 'dist/esm/index.d.ts');
+copyFileSync('index.d.ts', 'dist/cjs/index.d.cts');

--- a/test-types.ts
+++ b/test-types.ts
@@ -1,4 +1,7 @@
-import AccentFolding, { type AccentMap } from './index.js';
+import AccentFolding, {
+	type AccentMap,
+	type MatchPosition,
+} from 'accent-folding';
 
 // Constructor variants
 const af = new AccentFolding();
@@ -12,6 +15,9 @@ const replaced: string = af.replace('café');
 // highlightMatch() — two-arg and three-arg forms
 const highlighted: string = af.highlightMatch('López', 'lo');
 const highlightedTagged: string = af.highlightMatch('López', 'lo', 'mark');
+
+// matchPositions() returns MatchPosition[]
+const positions: MatchPosition[] = af.matchPositions('López', 'lo');
 
 // static method
 const entries: Array<[string, string]> =
@@ -33,5 +39,6 @@ af.highlightMatch('café', 42);
 	replaced,
 	highlighted,
 	highlightedTagged,
+	positions,
 	entries,
 	afMy);

--- a/test/integration/cjs.cjs
+++ b/test/integration/cjs.cjs
@@ -1,0 +1,69 @@
+/**
+ * CJS integration smoke test — run with: node test/integration/cjs.cjs
+ * Exercises the dist/cjs build to confirm it loads and behaves correctly.
+ */
+'use strict';
+
+const AccentFolding = require('../../dist/cjs/index.cjs');
+
+let passed = 0;
+let failed = 0;
+
+function assert(label, condition) {
+	if (condition) {
+		passed++;
+	} else {
+		failed++;
+		console.error(`  FAIL: ${label}`);
+	}
+}
+
+// --- require() shape: class should be the direct export (no .default needed) ---
+assert('require returns a class directly', typeof AccentFolding === 'function');
+assert('.default is also the class (interop)', typeof AccentFolding.default === 'function');
+
+const af = new AccentFolding();
+
+// --- replace ---
+assert('replace: strips accent', af.replace('café') === 'cafe');
+assert('replace: preserves ASCII', af.replace('hello') === 'hello');
+assert('replace: multi-char mapping (ß→ss)', af.replace('Straße') === 'Strasse');
+
+// --- highlightMatch ---
+assert(
+	'highlightMatch: wraps match preserving accented char',
+	af.highlightMatch('López', 'lo') === '<b>Ló</b>pez'
+);
+assert(
+	'highlightMatch: returns original when no match',
+	af.highlightMatch('Hello', 'xyz') === 'Hello'
+);
+assert(
+	'highlightMatch: custom tag',
+	af.highlightMatch('café', 'ca', 'mark') === '<mark>ca</mark>fé'
+);
+
+// --- matchPositions ---
+const positions = af.matchPositions('Fulanilo López', 'lo');
+assert('matchPositions: finds two matches', positions.length === 2);
+assert('matchPositions: start/end are numbers', typeof positions[0].start === 'number');
+assert(
+	'matchPositions: slices back to original text',
+	'Fulanilo López'.slice(positions[1].start, positions[1].end) === 'Ló'
+);
+assert('matchPositions: empty fragment → []', af.matchPositions('hello', '').length === 0);
+
+// --- custom map ---
+const afCustom = new AccentFolding({ ö: 'oe' });
+assert('custom map: override works', afCustom.replace('Föhn') === 'Foehn');
+
+// --- static method ---
+const entries = AccentFolding.convertAccentMapToArray({ á: 'a', ñ: 'n' });
+assert('convertAccentMapToArray returns pairs', entries.length === 2 && entries[0][0] === 'á');
+
+// --- result ---
+if (failed > 0) {
+	console.error(`\nCJS integration: ${failed} assertion(s) failed`);
+	process.exit(1);
+}
+console.log(`CJS integration: ${passed} assertions passed`);

--- a/test/integration/cjs.cjs
+++ b/test/integration/cjs.cjs
@@ -20,14 +20,20 @@ function assert(label, condition) {
 
 // --- require() shape: class should be the direct export (no .default needed) ---
 assert('require returns a class directly', typeof AccentFolding === 'function');
-assert('.default is also the class (interop)', typeof AccentFolding.default === 'function');
+assert(
+	'.default is also the class (interop)',
+	typeof AccentFolding.default === 'function'
+);
 
 const af = new AccentFolding();
 
 // --- replace ---
 assert('replace: strips accent', af.replace('café') === 'cafe');
 assert('replace: preserves ASCII', af.replace('hello') === 'hello');
-assert('replace: multi-char mapping (ß→ss)', af.replace('Straße') === 'Strasse');
+assert(
+	'replace: multi-char mapping (ß→ss)',
+	af.replace('Straße') === 'Strasse'
+);
 
 // --- highlightMatch ---
 assert(
@@ -46,12 +52,18 @@ assert(
 // --- matchPositions ---
 const positions = af.matchPositions('Fulanilo López', 'lo');
 assert('matchPositions: finds two matches', positions.length === 2);
-assert('matchPositions: start/end are numbers', typeof positions[0].start === 'number');
+assert(
+	'matchPositions: start/end are numbers',
+	typeof positions[0].start === 'number'
+);
 assert(
 	'matchPositions: slices back to original text',
 	'Fulanilo López'.slice(positions[1].start, positions[1].end) === 'Ló'
 );
-assert('matchPositions: empty fragment → []', af.matchPositions('hello', '').length === 0);
+assert(
+	'matchPositions: empty fragment → []',
+	af.matchPositions('hello', '').length === 0
+);
 
 // --- custom map ---
 const afCustom = new AccentFolding({ ö: 'oe' });
@@ -59,7 +71,10 @@ assert('custom map: override works', afCustom.replace('Föhn') === 'Foehn');
 
 // --- static method ---
 const entries = AccentFolding.convertAccentMapToArray({ á: 'a', ñ: 'n' });
-assert('convertAccentMapToArray returns pairs', entries.length === 2 && entries[0][0] === 'á');
+assert(
+	'convertAccentMapToArray returns pairs',
+	entries.length === 2 && entries[0][0] === 'á'
+);
 
 // --- result ---
 if (failed > 0) {

--- a/test/integration/esm.mjs
+++ b/test/integration/esm.mjs
@@ -24,7 +24,10 @@ const af = new AccentFolding();
 // --- replace ---
 assert('replace: strips accent', af.replace('café') === 'cafe');
 assert('replace: preserves ASCII', af.replace('hello') === 'hello');
-assert('replace: multi-char mapping (ß→ss)', af.replace('Straße') === 'Strasse');
+assert(
+	'replace: multi-char mapping (ß→ss)',
+	af.replace('Straße') === 'Strasse'
+);
 
 // --- highlightMatch ---
 assert(
@@ -43,12 +46,18 @@ assert(
 // --- matchPositions ---
 const positions = af.matchPositions('Fulanilo López', 'lo');
 assert('matchPositions: finds two matches', positions.length === 2);
-assert('matchPositions: start/end are numbers', typeof positions[0].start === 'number');
+assert(
+	'matchPositions: start/end are numbers',
+	typeof positions[0].start === 'number'
+);
 assert(
 	'matchPositions: slices back to original text',
 	'Fulanilo López'.slice(positions[1].start, positions[1].end) === 'Ló'
 );
-assert('matchPositions: empty fragment → []', af.matchPositions('hello', '').length === 0);
+assert(
+	'matchPositions: empty fragment → []',
+	af.matchPositions('hello', '').length === 0
+);
 
 // --- custom map ---
 const afCustom = new AccentFolding({ ö: 'oe' });
@@ -56,7 +65,10 @@ assert('custom map: override works', afCustom.replace('Föhn') === 'Foehn');
 
 // --- static method ---
 const entries = AccentFolding.convertAccentMapToArray({ á: 'a', ñ: 'n' });
-assert('convertAccentMapToArray returns pairs', entries.length === 2 && entries[0][0] === 'á');
+assert(
+	'convertAccentMapToArray returns pairs',
+	entries.length === 2 && entries[0][0] === 'á'
+);
 
 // --- result ---
 if (failed > 0) {

--- a/test/integration/esm.mjs
+++ b/test/integration/esm.mjs
@@ -1,0 +1,66 @@
+/**
+ * ESM integration smoke test — run with: node test/integration/esm.mjs
+ * Exercises the dist/esm build to confirm it loads and behaves correctly.
+ */
+import AccentFolding from '../../dist/esm/index.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(label, condition) {
+	if (condition) {
+		passed++;
+	} else {
+		failed++;
+		console.error(`  FAIL: ${label}`);
+	}
+}
+
+// --- import shape ---
+assert('default export is a class', typeof AccentFolding === 'function');
+
+const af = new AccentFolding();
+
+// --- replace ---
+assert('replace: strips accent', af.replace('café') === 'cafe');
+assert('replace: preserves ASCII', af.replace('hello') === 'hello');
+assert('replace: multi-char mapping (ß→ss)', af.replace('Straße') === 'Strasse');
+
+// --- highlightMatch ---
+assert(
+	'highlightMatch: wraps match preserving accented char',
+	af.highlightMatch('López', 'lo') === '<b>Ló</b>pez'
+);
+assert(
+	'highlightMatch: returns original when no match',
+	af.highlightMatch('Hello', 'xyz') === 'Hello'
+);
+assert(
+	'highlightMatch: custom tag',
+	af.highlightMatch('café', 'ca', 'mark') === '<mark>ca</mark>fé'
+);
+
+// --- matchPositions ---
+const positions = af.matchPositions('Fulanilo López', 'lo');
+assert('matchPositions: finds two matches', positions.length === 2);
+assert('matchPositions: start/end are numbers', typeof positions[0].start === 'number');
+assert(
+	'matchPositions: slices back to original text',
+	'Fulanilo López'.slice(positions[1].start, positions[1].end) === 'Ló'
+);
+assert('matchPositions: empty fragment → []', af.matchPositions('hello', '').length === 0);
+
+// --- custom map ---
+const afCustom = new AccentFolding({ ö: 'oe' });
+assert('custom map: override works', afCustom.replace('Föhn') === 'Foehn');
+
+// --- static method ---
+const entries = AccentFolding.convertAccentMapToArray({ á: 'a', ñ: 'n' });
+assert('convertAccentMapToArray returns pairs', entries.length === 2 && entries[0][0] === 'á');
+
+// --- result ---
+if (failed > 0) {
+	console.error(`\nESM integration: ${failed} assertion(s) failed`);
+	process.exit(1);
+}
+console.log(`ESM integration: ${passed} assertions passed`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,10 @@
     "noEmit": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "target": "ES2022"
+    "target": "ES2022",
+    "paths": {
+      "accent-folding": ["./index.d.ts"]
+    }
   },
   "include": ["test-types.ts"]
 }

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+	{
+		entry: { index: 'src/accentFolding.js' },
+		format: ['esm'],
+		outDir: 'dist/esm',
+		clean: true,
+	},
+	{
+		entry: { index: 'src/accentFolding.js' },
+		format: ['cjs'],
+		outDir: 'dist/cjs',
+		clean: false,
+		footer: {
+			js: 'var _d = module.exports.default; module.exports = _d; module.exports.default = _d;',
+		},
+	},
+]);

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -11,7 +11,7 @@ export default defineConfig([
 		entry: { index: 'src/accentFolding.js' },
 		format: ['cjs'],
 		outDir: 'dist/cjs',
-		clean: false,
+		clean: true,
 		footer: {
 			js: 'var _d = module.exports.default; module.exports = _d; module.exports.default = _d;',
 		},


### PR DESCRIPTION
Closes #71.

## Summary

- **Dual build**: tsup produces `dist/esm/index.js` (ESM) and `dist/cjs/index.cjs` (CJS) from a single source file. The CJS output uses an interop footer so `require('accent-folding')` returns the class directly — no `.default` needed.
- **Exports map**: `import` condition → ESM, `require` condition → CJS; `main` and `module` fields kept for legacy tools.
- **Type declarations**: `index.d.ts` stays the hand-authored source of truth; the build copies it to both `dist/esm/index.d.ts` and `dist/cjs/index.d.cts`.
- **Integration tests**: `test/integration/esm.mjs` (13 assertions) and `test/integration/cjs.cjs` (14 assertions) exercise the actual dist artefacts in both module systems.
- **CI**: `coverage.yml` runs `build → type-check → publint → size → unit tests → integration tests`; `release.yml` builds before publish.
- **Bundle sizes**: ESM 2.36 kB, CJS 2.63 kB — both under the 4 kB limit.
- **Lint fix**: `demo/dist/` added to ESLint ignores (minified Vite output was triggering false positives).

## Test plan

- [x] `pnpm run build` — ESM and CJS outputs appear in `dist/`
- [x] `pnpm run type-check` — passes with `paths` alias resolving `accent-folding` → local `index.d.ts`
- [x] `pnpm run publint` — All good
- [x] `pnpm run size` — ESM and CJS both under 4 kB
- [x] `pnpm run coverage` — 756 tests, 100% coverage
- [x] `pnpm run test:integration` — ESM: 13 passed, CJS: 14 passed
- [x] `pnpm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)